### PR TITLE
feat: add missing rpc methods

### DIFF
--- a/rpc/debug/traceCall/index.test.ts
+++ b/rpc/debug/traceCall/index.test.ts
@@ -3,10 +3,7 @@ import debug_traceCall from "./index";
 import evaluateResponse from "../../../utils/evaluateResponse";
 
 describe("debug_traceCall", () => {
-  it(`
-    Lets you run an eth_call within the context of the given block execution 
-    using the final state of parent block as the base.
-    `, async () => {
+  it("Lets you run an eth_call within the context of the given block execution using the final state of parent block as the base.", async () => {
     evaluateResponse({
       response: await debug_traceCall(), 
       pattern: null,

--- a/rpc/debug/traceTransaction/index.test.ts
+++ b/rpc/debug/traceTransaction/index.test.ts
@@ -3,11 +3,7 @@ import debug_traceTransaction from "./index";
 import evaluateResponse from "../../../utils/evaluateResponse";
 
 describe("debug_traceTransaction", () => {
-  it(`
-    Attempts to run the transaction in the exact same manner as it was executed on the network.
-    It will replay any transaction that may have been executed prior to this one before it will 
-    finally attempt to execute the transaction that corresponds to the given hash.
-    `, async () => {
+  it("Attempts to run the transaction in the exact same manner as it was executed on the network. It will replay any transaction that may have been executed prior to this one before it will finally attempt to execute the transaction that corresponds to the given hash.", async () => {
     evaluateResponse({
       response: await debug_traceTransaction(), 
       pattern: null,

--- a/rpc/eth/accounts/index.test.ts
+++ b/rpc/eth/accounts/index.test.ts
@@ -1,0 +1,16 @@
+import { describe } from "@jest/globals";
+import eth_accounts from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+import patternGenerator from "../../../utils/patternGenerator";
+
+describe("eth_accounts", () => {
+  it("Returns a list of addresses owned by client.", async () => {
+    evaluateResponse({
+      response: await eth_accounts(), 
+      pattern: await patternGenerator.buildArrayPattern({
+        rpcDefinitionPath: "../execution-apis/src/eth/client.yaml",
+        rpcName: "eth_accounts",
+      }),
+    });
+  });
+});

--- a/rpc/eth/accounts/index.ts
+++ b/rpc/eth/accounts/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const eth_accounts = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "eth_accounts",
+      params: [],
+    },
+  });
+
+export default eth_accounts;

--- a/rpc/net/listening/index.test.ts
+++ b/rpc/net/listening/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import net_listening from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("net_listening", () => {
+  it("Returns true if client is actively listening for network connections.", async () => {
+    evaluateResponse({
+      response: await net_listening(), 
+      pattern: null,
+    });
+  });
+});

--- a/rpc/net/listening/index.ts
+++ b/rpc/net/listening/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const net_listening = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "net_listening",
+      params: [],
+    },
+  });
+
+export default net_listening;

--- a/rpc/net/peerCount/index.test.ts
+++ b/rpc/net/peerCount/index.test.ts
@@ -1,0 +1,14 @@
+import { describe } from "@jest/globals";
+import net_peerCount from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+import patternGenerator from "../../../utils/patternGenerator";
+
+describe("net_peerCount", () => {
+  it("Returns number of peers currently connected to the client.", async () => {
+    const schema = await patternGenerator.getSchema();
+    evaluateResponse({
+      response: await net_peerCount(), 
+      pattern: new RegExp(schema.uint.pattern),
+    });
+  });
+});

--- a/rpc/net/peerCount/index.ts
+++ b/rpc/net/peerCount/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const net_peerCount = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "net_peerCount",
+      params: [],
+    },
+  });
+
+export default net_peerCount;

--- a/rpc/net/version/index.test.ts
+++ b/rpc/net/version/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import net_version from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("net_version", () => {
+  it("Returns a list of addresses owned by client.", async () => {
+    evaluateResponse({
+      response: await net_version(), 
+      pattern: null,
+    });
+  });
+});

--- a/rpc/net/version/index.ts
+++ b/rpc/net/version/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const net_version = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "net_version",
+      params: [],
+    },
+  });
+
+export default net_version;

--- a/rpc/txpool/content/index.test.ts
+++ b/rpc/txpool/content/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import txpool_content from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("txpool_content", () => {
+  it("The content inspection property can be queried to list the exact details of all the transactions currently pending for inclusion in the next block(s), as well as the ones that are being scheduled for future execution only. The result is an object with two fields pending and queued. Each of these fields are associative arrays, in which each entry maps an origin-address to a batch of scheduled transactions. These batches themselves are maps associating nonces with actual transactions. Please note, there may be multiple transactions associated with the same account and nonce. This can happen if the user broadcast mutliple ones with varying gas allowances (or even completely different transactions).", async () => {
+    evaluateResponse({
+      response: await txpool_content(),
+      pattern: null,
+    });
+  });
+});

--- a/rpc/txpool/content/index.ts
+++ b/rpc/txpool/content/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const txpool_content = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "txpool_content",
+      params: [],
+    },
+  });
+
+export default txpool_content;

--- a/rpc/txpool/contentFrom/index.test.ts
+++ b/rpc/txpool/contentFrom/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import txpool_contentFrom from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("txpool_contentFrom", () => {
+  it("The content inspection property can be queried to list the exact details of all the transactions currently pending for inclusion in the next block(s), as well as the ones that are being scheduled for future execution only. The result is an object with two fields pending and queued. Each of these fields are associative arrays, in which each entry maps an origin-address to a batch of scheduled transactions. These batches themselves are maps associating nonces with actual transactions. Please note, there may be multiple transactions associated with the same account and nonce. This can happen if the user broadcast mutliple ones with varying gas allowances (or even completely different transactions).", async () => {
+    evaluateResponse({
+      response: await txpool_contentFrom(), 
+      pattern: null,
+    });
+  });
+});

--- a/rpc/txpool/contentFrom/index.ts
+++ b/rpc/txpool/contentFrom/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const txpool_contentFrom = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "txpool_contentFrom",
+      params: ["0xA8416AbBf1291a0aF73B4B3852C44284e7Bb5cca"],
+    },
+  });
+
+export default txpool_contentFrom;

--- a/rpc/txpool/inspect/index.test.ts
+++ b/rpc/txpool/inspect/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import txpool_inspect from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("txpool_inspect", () => {
+  it("The inspect inspection property can be queried to list a textual summary of all the transactions currently pending for inclusion in the next block(s), as well as the ones that are being scheduled for future execution only. This is a method specifically tailored to developers to quickly see the transactions in the pool and find any potential issues. The result is an object with two fields pending and queued. Each of these fields are associative arrays, in which each entry maps an origin-address to a batch of scheduled transactions. These batches themselves are maps associating nonces with transactions summary strings. Please note, there may be multiple transactions associated with the same account and nonce. This can happen if the user broadcast mutliple ones with varying gas allowances (or even completely different transactions).", async () => {
+    evaluateResponse({
+      response: await txpool_inspect(), 
+      pattern: null,
+    });
+  });
+});

--- a/rpc/txpool/inspect/index.ts
+++ b/rpc/txpool/inspect/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const txpool_inspect = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "txpool_inspect",
+      params: [],
+    },
+  });
+
+export default txpool_inspect;

--- a/rpc/txpool/status/index.test.ts
+++ b/rpc/txpool/status/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import txpool_status from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("txpool_status", () => {
+  it("The status inspection property can be queried to know how many transactions are currently pending for inclusion in the next block(s), and how many are being scheduled for future execution. The result is an object with two fields pending and queued.", async () => {
+    evaluateResponse({
+      response: await txpool_status(), 
+      pattern: null,
+    });
+  });
+});

--- a/rpc/txpool/status/index.ts
+++ b/rpc/txpool/status/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const txpool_status = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "txpool_status",
+      params: [],
+    },
+  });
+
+export default txpool_status;

--- a/rpc/web3/clientVersion/index.test.ts
+++ b/rpc/web3/clientVersion/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import web3_clientVersion from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("web3_clientVersion", () => {
+  it("Returns the current client version.", async () => {
+    evaluateResponse({
+      response: await web3_clientVersion(), 
+      pattern: null,
+    });
+  });
+});

--- a/rpc/web3/clientVersion/index.ts
+++ b/rpc/web3/clientVersion/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const web3_clientVersion = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "web3_clientVersion",
+      params: [],
+    },
+  });
+
+export default web3_clientVersion;

--- a/rpc/web3/sha3/index.test.ts
+++ b/rpc/web3/sha3/index.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "@jest/globals";
+import web3_sha3 from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+
+describe("web3_sha3", () => {
+  it("Returns Keccak-256 (not the standardized _SHA3_-256) hash of the given data.", async () => {
+    evaluateResponse({
+      response: await web3_sha3(), 
+      pattern: null,
+    });
+  });
+});

--- a/rpc/web3/sha3/index.ts
+++ b/rpc/web3/sha3/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const web3_sha3 = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "web3_sha3",
+      params: ["0x10FEDe72EEd94284B8Aa7002A8D46b347D83B91B"],
+    },
+  });
+
+export default web3_sha3;

--- a/rpc/zen/getFeePayments/index.test.ts
+++ b/rpc/zen/getFeePayments/index.test.ts
@@ -1,0 +1,19 @@
+import { describe } from "@jest/globals";
+import zen_getFeePayments from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+import patternGenerator from "../../../utils/patternGenerator";
+
+describe("zen_getFeePayments", () => {
+  it("Returns the list of the forger rewards (recipients and values) distributed at the specified block.", async () => {
+    const schema = await patternGenerator.getSchema();
+    evaluateResponse({
+      response: await zen_getFeePayments(), 
+      pattern: {
+        forwardTransfers: [{
+          to: new RegExp(schema.address.pattern),
+          value: new RegExp(schema.uint.pattern),
+        }],
+      },
+    });
+  });
+});

--- a/rpc/zen/getFeePayments/index.ts
+++ b/rpc/zen/getFeePayments/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const zen_getFeePayments = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "zen_getFeePayments",
+      params: [33414],
+    },
+  });
+
+export default zen_getFeePayments;

--- a/rpc/zen/getForwardTransfers/index.test.ts
+++ b/rpc/zen/getForwardTransfers/index.test.ts
@@ -1,0 +1,19 @@
+import { describe } from "@jest/globals";
+import zen_getForwardTransfers from "./index";
+import evaluateResponse from "../../../utils/evaluateResponse";
+import patternGenerator from "../../../utils/patternGenerator";
+
+describe("zen_getForwardTransfers", () => {
+  it("Returns the list of Forward Transfers (Zen coming from the Horizen Mainchain) at a specified block.", async () => {
+    const schema = await patternGenerator.getSchema();
+    evaluateResponse({
+      response: await zen_getForwardTransfers(), 
+      pattern: {
+        forwardTransfers: [{
+          to: new RegExp(schema.address.pattern),
+          value: new RegExp(schema.uint.pattern),
+        }],
+      },
+    });
+  });
+});

--- a/rpc/zen/getForwardTransfers/index.ts
+++ b/rpc/zen/getForwardTransfers/index.ts
@@ -1,0 +1,15 @@
+import fetchAPI from "../../../utils/fetchAPI";
+import { JSONRPC } from "../../../utils/types";
+import fixtures from "../../../fixtures";
+
+const zen_getForwardTransfers = async ():
+  Promise<JSONRPC> => await fetchAPI({
+    options: {
+      id: fixtures.id,
+      jsonrpc: fixtures.jsonrpc,
+      method: "zen_getForwardTransfers",
+      params: ["0x19552"],
+    },
+  });
+
+export default zen_getForwardTransfers;

--- a/utils/patternGenerator.ts
+++ b/utils/patternGenerator.ts
@@ -137,6 +137,7 @@ async function buildStringPattern({ rpcDefinitionPath, rpcName }) {
 }
 
 export default {
+  getSchema,
   buildArrayPattern,
   buildObjectPattern,
   buildStringPattern,


### PR DESCRIPTION
### Ticket

https://horizenlabs.atlassian.net/browse/QA-36

### Changes

- add missing rpc methods: `eth_accounts`, `eth_getLogs`, `net_version`, `web3_clientVersion`, `web3_sha3`, `txpool_status`, `txpool_content`, `txpool_contentFrom`, `txpool_inspect`, `net_peerCount`, `net_listening`, `zen_getFeePayments`, `zen_getForwardTransfers`