### PR TITLE
Sdk 1532

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,19 @@ script:
   # Test Commands
   - >
     if [ "$TEST_ENV" = "local" ]; then 
-      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-local 2>&1);
+      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e SEND_FROM_PK2=$SEND_FROM_PK2 -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-local 2>&1);
     fi
   - >
     if [ "$TEST_ENV" = "pregobi" ]; then 
-      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-pregobi 2>&1);
+      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e SEND_FROM_PK2=$SEND_FROM_PK2 -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-pregobi 2>&1);
     fi
   - >
     if [ "$TEST_ENV" = "gobi" ]; then 
-      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-gobi 2>&1);
+      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e SEND_FROM_PK2=$SEND_FROM_PK2 -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-gobi 2>&1);
     fi
   - >
     if [ "$TEST_ENV" = "eon" ]; then 
-      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-eon 2>&1);
+      TEST_OUTPUT=$(docker run -e SEND_FROM_PK=$SEND_FROM_PK -e SEND_FROM_PK2=$SEND_FROM_PK2 -e RPC_USERNAME=$RPC_USERNAME -e RPC_PASSWORD=$RPC_PASSWORD -v $(pwd):/usr/src/app -v $(pwd)/reports:/usr/src/app/reports rpc-tests npm run test-eon 2>&1);
     fi
 
   - echo "$TEST_OUTPUT";

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ These tests require basic auth username and password to be set:
 
 ## Send Transaction Tests
 
-These tests require adding the Private Key (PK) of the sending wallet to the .env as:
+These tests require adding 2 Private Keys (PKs) of the sending wallets to the .env as:
 
     SEND_FROM_PK=
+    SEND_FROM_PK2=
 
-This should not be committed.
+This should not be committed.  We use multiple wallets so that nonce values are not confused during parallel testing.
 
 To run EOA to EOA test:
 

--- a/rpc/transactions/contract/index.test.ts
+++ b/rpc/transactions/contract/index.test.ts
@@ -69,9 +69,13 @@ describe("Contract Deployment & Interaction", () => {
         const amountB = "1000000000";
 
         await approveAndCheck(web3, tokenA, spender, amountA, account.address);
+        console.log("Successfully called approve for tokenA/spender")
         await approveAndCheck(web3, tokenB, spender, amountB, account.address);
+        console.log("Successfully called approve for tokenB/spender")
         await approveAndCheck(web3, weth, wethAddress, amountA, account.address);
+        console.log("Successfully called approve for weth/wethAddress")
         await approveAndCheck(web3, weth, spender, amountA, account.address);
+        console.log("Successfully called approve for weth/spender")
 
         // deadline
         const time = Math.floor(Date.now() / 1000) + 200000;

--- a/rpc/transactions/contract/index.ts
+++ b/rpc/transactions/contract/index.ts
@@ -181,7 +181,7 @@ export const approve = async (
         const [transactionHash, receipt] = await Promise.all([transactionHashPromise, receiptPromise]);
         return { transactionHash, receipt };
     } catch (error) {
-        console.error("Error sending transaction:", error);
+        console.error("Error sending 'approve' transaction:", error);
         throw error;
     }
 }
@@ -262,7 +262,7 @@ export const addLiquidity = async (
         const [transactionHash, receipt] = await Promise.all([transactionHashPromise, receiptPromise]);
         return { transactionHash, receipt };
     } catch (error) {
-        console.error("Error sending transaction:", error);
+        console.error("Error sending 'addLiquidity' transaction:", error);
         throw error;
     }
 }

--- a/rpc/transactions/contract/index.ts
+++ b/rpc/transactions/contract/index.ts
@@ -5,6 +5,7 @@ import ERC20 from "../../../node_modules/@openzeppelin/contracts/build/contracts
 import WETH from "../../../node_modules/canonical-weth/build/contracts/WETH9.json";
 import { Contract } from "web3-eth-contract"
 import { getCurrentDateTokens } from "../../../utils/web3utils";
+import {rootCertificates} from "tls";
 
 export const deployWeth: (web3: Web3, sender: string) => Promise<string | undefined> = async (web3, sender) => {
     const wethContract = new web3.eth.Contract(WETH.abi as any);
@@ -134,7 +135,7 @@ export const approve = async (
     spender: string,
     amount: string,
     sender: string
-): Promise<{transactionHash?: string, receipt?: any}> => {
+): Promise<{ transactionHash?: string, receipt?: any }> => {
     let estimatedGas;
 
     try {
@@ -161,27 +162,26 @@ export const approve = async (
 
     const signedTx = await web3.eth.accounts.signTransaction(tx, process.env.SEND_FROM_PK);
 
-    const transactionHashPromise = new Promise<string>((resolve, reject) => {
+    let transactionHash;
+    let receipt;
+
+    const transactionResultPromise = new Promise<{ transactionHash?: string, receipt?: any }>((resolve, reject) => {
         web3.eth.sendSignedTransaction(signedTx.rawTransaction!)
             .on('transactionHash', function (hash) {
-                resolve(hash.toString());
+                transactionHash = hash.toString();
+                console.log("approve transactionHash: " + transactionHash);
             })
-            .on('error', reject);
-    });
-
-    const receiptPromise = new Promise<any>((resolve, reject) => {
-        web3.eth.sendSignedTransaction(signedTx.rawTransaction!)
             .on('receipt', function (rec) {
-                resolve(rec);
+                receipt = rec;
+                resolve({ transactionHash, receipt });
             })
             .on('error', reject);
     });
 
     try {
-        const [transactionHash, receipt] = await Promise.all([transactionHashPromise, receiptPromise]);
-        return { transactionHash, receipt };
+        return await transactionResultPromise;
     } catch (error) {
-        console.error("Error sending 'approve' transaction:", error);
+        console.error("Error sending 'approve'", error);
         throw error;
     }
 }
@@ -197,7 +197,7 @@ export const addLiquidity = async (
     amountBMin: string,
     sender: string,
     deadline: string
-): Promise<{transactionHash?: string, receipt?: any}> => {
+): Promise<{ transactionHash?: string, receipt?: any }> => {
     let estimatedGas;
 
     try {
@@ -242,27 +242,26 @@ export const addLiquidity = async (
 
     const signedTx = await web3.eth.accounts.signTransaction(tx, process.env.SEND_FROM_PK);
 
-    const transactionHashPromise = new Promise<string>((resolve, reject) => {
+    let transactionHash;
+    let receipt;
+
+    const transactionResultPromise = new Promise<{ transactionHash?: string, receipt?: any }>((resolve, reject) => {
         web3.eth.sendSignedTransaction(signedTx.rawTransaction!)
             .on('transactionHash', function (hash) {
-                resolve(hash.toString());
+                transactionHash = hash.toString();
+                console.log("addLiquidity transactionHash: " + transactionHash);
             })
-            .on('error', reject);
-    });
-
-    const receiptPromise = new Promise<any>((resolve, reject) => {
-        web3.eth.sendSignedTransaction(signedTx.rawTransaction!)
             .on('receipt', function (rec) {
-                resolve(rec);
+                receipt = rec;
+                resolve({ transactionHash, receipt });
             })
             .on('error', reject);
     });
 
     try {
-        const [transactionHash, receipt] = await Promise.all([transactionHashPromise, receiptPromise]);
-        return { transactionHash, receipt };
+        return await transactionResultPromise;
     } catch (error) {
-        console.error("Error sending 'addLiquidity' transaction:", error);
+        console.error("Error sending 'addLiquidity'", error);
         throw error;
     }
 }

--- a/rpc/transactions/eoa/index.test.ts
+++ b/rpc/transactions/eoa/index.test.ts
@@ -3,7 +3,7 @@ import Web3 from "web3";
 import BN from "bn.js";
 import { describe, expect } from "@jest/globals";
 import { formatPrivateKey } from "../../../utils/web3utils";
-import sendTransaction from "./index";
+import sendTransaction, {getReceipt} from "./index";
 
 const { RPC_URL, SEND_FROM_PK, SEND_TO_ADDRESS, SEND_AMOUNT } = process.env;
 
@@ -16,16 +16,47 @@ describe("web3_sendTransaction", () => {
         throw new Error("SEND_FROM_PK is missing from the environment variables. Please set it in the .env file.");
     }
 
-    it("Sends a transaction from EOA to EOA and confirms balance change.", async () => {
+    it("Sends a future nonce transaction, checks the mempool and then sends the correct nonce from EOA to EOA " +
+        "and confirms sender and receiver balance changes for both transactions.", async () => {
+
+        const account = web3.eth.accounts.privateKeyToAccount(formatPrivateKey(web3, SEND_FROM_PK));
 
         // Get the initial balances of both addresses BEFORE the transaction
-        const initialSenderBalance = await web3.eth.getBalance(
-            web3.eth.accounts.privateKeyToAccount(formatPrivateKey(web3, SEND_FROM_PK)).address);
-
+        const initialSenderBalance = await web3.eth.getBalance(account.address);
         const initialReceiverBalance = await web3.eth.getBalance(SEND_TO_ADDRESS);
 
-        // Send the transaction
-        const { sender, txHash, receipt } = await sendTransaction(
+        // Send the transaction with a future nonce
+        const { txHash: futureTxHash } = await sendTransaction(
+            web3,
+            SEND_FROM_PK,
+            SEND_TO_ADDRESS,
+            SEND_AMOUNT,
+            1
+        );
+
+        expect(futureTxHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+        // Fetch future transaction from the mempool using its tx hash
+        const MAX_RETRIES = 10;
+        let transaction;
+
+        for (let i = 0; i < MAX_RETRIES; i++) {
+            try {
+                transaction = await web3.eth.getTransaction(futureTxHash);
+                if (transaction) {
+                    break;
+                }
+            } catch (e) {
+                if (i === MAX_RETRIES - 1) {
+                    throw new Error("Unable to retrieve mempool transaction after " + MAX_RETRIES + " attempts: " + e);
+                }
+            }
+            await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+
+        expect(transaction.hash).toBe(futureTxHash);
+
+        const { txHash, receipt } = await sendTransaction(
             web3,
             SEND_FROM_PK,
             SEND_TO_ADDRESS,
@@ -36,20 +67,28 @@ describe("web3_sendTransaction", () => {
         expect(txHash).toMatch(/^0x[a-fA-F0-9]{64}$/);
         expect(receipt.transactionHash).toBe(txHash);
 
+        const futureReceipt = await getReceipt(web3, futureTxHash);
+        expect(futureReceipt.transactionHash).toBe(futureTxHash);
+
+        // Calculate gas costs for both transactions
+        const gasCostForTx = new BN(receipt.gasUsed).mul(new BN(web3.utils.toWei('20', 'gwei')));
+        const gasCostForFutureTx = new BN(futureReceipt.gasUsed).mul(new BN(web3.utils.toWei('20', 'gwei')));
+
+        // Calculate total costs for both transactions
+        const totalSentAmountForTx = new BN(web3.utils.toWei(SEND_AMOUNT, 'ether')).add(gasCostForTx);
+        const totalSentAmountForFutureTx = new BN(web3.utils.toWei(SEND_AMOUNT, 'ether')).add(gasCostForFutureTx);
+        const totalTransactionCost = totalSentAmountForTx.add(totalSentAmountForFutureTx);
+
         // Get the balances of both addresses again AFTER the transaction
-        const newSenderBalance = await web3.eth.getBalance(sender);
+        const newSenderBalance = await web3.eth.getBalance(account.address);
         const newReceiverBalance = await web3.eth.getBalance(SEND_TO_ADDRESS);
 
-        // Confirm the difference in the sender's balance
-        const transactionCost = new BN(initialSenderBalance).sub(new BN(newSenderBalance));
-        // TODO consider using estimateGas instead of hardcoding 20 gwei.
-        const gasCost = new BN(receipt.gasUsed).mul(new BN(web3.utils.toWei('20', 'gwei')));
-        const totalSentAmount = new BN(web3.utils.toWei(SEND_AMOUNT, 'ether')).add(gasCost);
-        expect(transactionCost.toString()).toBe(totalSentAmount.toString());
+        // Confirm the transaction costs are correctly deducted from the sender balance
+        const senderBalanceDifference = new BN(initialSenderBalance).sub(new BN(newSenderBalance));
+        expect(senderBalanceDifference.toString()).toBe(totalTransactionCost.toString());
 
         // Confirm the difference in the receiver's balance
-        const amountReceivedInWei = web3.utils.toWei(SEND_AMOUNT, 'ether');
-        expect(new BN(newReceiverBalance).sub(new BN(initialReceiverBalance)).toString()).toBe(amountReceivedInWei);
+        const totalReceivedAmountInWei = (new BN(web3.utils.toWei(SEND_AMOUNT, 'ether'))).mul(new BN('2'));
+        expect(new BN(newReceiverBalance).sub(new BN(initialReceiverBalance)).toString()).toBe(totalReceivedAmountInWei.toString());
     }, 60000);
 });
-

--- a/utils/evaluateResponse.ts
+++ b/utils/evaluateResponse.ts
@@ -135,6 +135,7 @@ function evaluateResponse({ response, pattern, expectNullResult = false }) {
     if (value === null) {
       throw new Error('Unexpected null result');
     }
+
     reduceValue(value, pattern);
   }
 


### PR DESCRIPTION
Add additional PK so contract and transaction tests dont get confused using the same nonces.

Amended the transaction test so it sends a future nonce and checks the mempool for its presence before then sending the correct nonce and asserting both transactions were successfully mined.