### PR TITLE
Following a fix to the return value of zen_getFeePayments an update i…

### DIFF
--- a/rpc/zen/getFeePayments/index.test.ts
+++ b/rpc/zen/getFeePayments/index.test.ts
@@ -5,6 +5,8 @@ import patternGenerator from "../../../utils/patternGenerator";
 
 describe("zen_getFeePayments", () => {
   it("Returns the list of the forger rewards (recipients and values) distributed at the specified block.", async () => {
+    // TODO:  1.3.0 returns empty array instead of null, update this each time we deploy to an env and remove once live on EON.
+    const expectNull = !(process.env.BLOCKSCOUT_API && process.env.BLOCKSCOUT_API.includes('pregobi'))
     const schema = await patternGenerator.getSchema();
     evaluateResponse({
       response: await zen_getFeePayments(), 
@@ -14,7 +16,7 @@ describe("zen_getFeePayments", () => {
           value: new RegExp(schema.uint.pattern),
         }],
       },
-      expectNullResult: true
+      expectNullResult: expectNull
     });
   });
 });


### PR DESCRIPTION
Fix the test for pre-gobi, zen_getFeePayments now returns an empty array instead of a null result.

Will need another change once we deploy 1.3.0 on Gobi, and again for EON.