### PR TITLE
Remove expect null from zen_getFeePayments test now we have deployed to EON

### DIFF
--- a/rpc/zen/getFeePayments/index.test.ts
+++ b/rpc/zen/getFeePayments/index.test.ts
@@ -5,8 +5,6 @@ import patternGenerator from "../../../utils/patternGenerator";
 
 describe("zen_getFeePayments", () => {
   it("Returns the list of the forger rewards (recipients and values) distributed at the specified block.", async () => {
-    // TODO:  1.3.0 returns empty array instead of null, update this each time we deploy to an env and remove once live on EON.
-    const expectNull = !(process.env.BLOCKSCOUT_API && process.env.BLOCKSCOUT_API.includes('gobi'))
     const schema = await patternGenerator.getSchema();
     evaluateResponse({
       response: await zen_getFeePayments(), 
@@ -15,8 +13,7 @@ describe("zen_getFeePayments", () => {
           to: new RegExp(schema.address.pattern),
           value: new RegExp(schema.uint.pattern),
         }],
-      },
-      expectNullResult: expectNull
+      }
     });
   });
 });


### PR DESCRIPTION
Remove expect null from zen_getFeePayments test now we have deployed to EON and all environments are expected to return an empty array